### PR TITLE
Add NOHUB path block

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ We block packets from the following 'tocall' destinations:
 
 We block packets with the following in their path:
  - `SONDEGATE` - Radiosonde Gateways
+ - `NOHUB` - Use this if you want to send packets into APRS-IS that you *don't* want imported.
 
 We block packets from the following source callsigns:
  - Any source callsign containing `WIDE`, which usually indicates a corrupted packet.

--- a/sondehub_aprs_gw/__main__.py
+++ b/sondehub_aprs_gw/__main__.py
@@ -82,6 +82,10 @@ BLOCKED_FROMCALLS = (
 def isHam(thing):
     if "SONDEGATE" in thing["path"]: # {'raw': 'T1310753>APRARX,SONDEGATE,TCPIP,qAR,DF7OA-12:/233445h5242.24N/00959.93EO152/042/A=043155 Clb=3.7m/s t=-55.5C 405.701 MHz Type=RS41-SGP Radiosonde auto_rx v1.3.2 !w,%!', 'from': 'T1310753', 'to': 'APRARX', 'path': ['SONDEGATE', 'TCPIP', 'qAR', 'DF7OA-12'], 'via': 'DF7OA-12', 'messagecapable': False, 'raw_timestamp': '233445h', 'timestamp': 1641771285, 'format': 'uncompressed', 'posambiguity': 0, 'symbol': 'O', 'symbol_table': '/', 'latitude': 52.70402014652015, 'longitude': 9.99884065934066, 'course': 152, 'speed': 77.784, 'altitude': 13153.644, 'daodatumbyte': 'W', 'comment': 'Clb=3.7m/s t=-55.5C 405.701 MHz Type=RS41-SGP Radiosonde auto_rx v1.3.2'}
         return False
+    
+    # Block packets that users specifically want excluded fron the gateway.
+    if "NOHUB" in thing["path"]:
+        return False
 
     if thing["to"].startswith(BLOCKED_TOCALLS): 
         return False


### PR DESCRIPTION
On request from a user - a way that they can send packets for display via APRS-IS that do *not* end up imported back into SondeHub.